### PR TITLE
Fixes to loot system

### DIFF
--- a/src/game/Group/Group.cpp
+++ b/src/game/Group/Group.cpp
@@ -912,10 +912,10 @@ void Group::CountTheRoll(Rolls::iterator& rollI)
             SendLootRollWon(maxguid, maxresul, ROLL_GREED, *roll);
             player = sObjectMgr.GetPlayer(maxguid);
 
+            LootItem *item = &(roll->getLoot()->items[roll->itemSlot]);
             if (player && player->GetSession())
             {
                 ItemPosCountVec dest;
-                LootItem *item = &(roll->getLoot()->items[roll->itemSlot]);
                 InventoryResult msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, roll->itemid, item->count);
                 if (msg == EQUIP_ERR_OK)
                 {
@@ -923,16 +923,19 @@ void Group::CountTheRoll(Rolls::iterator& rollI)
                     roll->getLoot()->NotifyItemRemoved(roll->itemSlot);
                     --roll->getLoot()->unlootedCount;
                     sLog.out(LOG_LOOTS, "%s wins greed roll for %ux%u [loot from %s]",
-                             player->GetShortDescription().c_str(), item->count, item->itemid, roll->lootedTargetGUID.GetString().c_str());
+                        player->GetShortDescription().c_str(), item->count, item->itemid, roll->lootedTargetGUID.GetString().c_str());
                     if (Item* newItem = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId))
                         player->OnReceivedItem(newItem);
                 }
                 else
                 {
                     item->is_blocked = false;
+                    item->lootOwner = maxguid;
                     player->SendEquipError(msg, NULL, NULL, roll->itemid);
                 }
             }
+            else
+                item->lootOwner = maxguid;
         }
     }
     else

--- a/src/game/Group/Group.cpp
+++ b/src/game/Group/Group.cpp
@@ -763,15 +763,17 @@ void Group::StartLootRoll(Creature* lootTarget, LootMethod method, Loot* loot, u
         r->itemSlot = itemSlot;
 
         if (r->totalPlayersRolling == 1)                    // single looter
+        {
             r->playerVote.begin()->second = ROLL_NEED;
+            CountSingleLooterRoll(r);
+        }
         else
         {
             SendLootStartRoll(LOOT_ROLL_TIMEOUT, *r);
             loot->items[itemSlot].is_blocked = true;
             lootTarget->StartGroupLoot(this, LOOT_ROLL_TIMEOUT);
+            RollId.push_back(r);
         }
-
-        RollId.push_back(r);
     }
     else                                            // no looters??
         delete r;
@@ -790,6 +792,38 @@ void Group::EndRoll(Loot* loot)
         else
             itr++;
     }
+}
+
+void Group::CountSingleLooterRoll(Roll* roll)
+{
+    ObjectGuid playerGuid = roll->playerVote.begin()->first;
+    Player* player = sObjectMgr.GetPlayer(playerGuid);
+    SendLootRollWon(playerGuid, uint8(100), ROLL_NEED, *roll);
+
+    LootItem *item = &(roll->getLoot()->items[roll->itemSlot]);
+    if (player && player->GetSession())
+    {
+        ItemPosCountVec dest;
+        InventoryResult msg = player->CanStoreNewItem(NULL_BAG, NULL_SLOT, dest, roll->itemid, item->count);
+        if (msg == EQUIP_ERR_OK)
+        {
+            item->is_looted = true;
+            roll->getLoot()->NotifyItemRemoved(roll->itemSlot);
+            --roll->getLoot()->unlootedCount;
+            sLog.out(LOG_LOOTS, "%s wins need roll for %ux%u [loot from %s]",
+                player->GetShortDescription().c_str(), item->count, item->itemid, roll->lootedTargetGUID.GetString().c_str());
+            if (Item* newItem = player->StoreNewItem(dest, roll->itemid, true, item->randomPropertyId))
+                player->OnReceivedItem(newItem);
+        }
+        else
+        {
+            item->is_blocked = false;
+            item->lootOwner = playerGuid;
+            player->SendEquipError(msg, NULL, NULL, roll->itemid);
+        }
+    }
+
+    delete roll;
 }
 
 void Group::CountTheRoll(Rolls::iterator& rollI)

--- a/src/game/Group/Group.h
+++ b/src/game/Group/Group.h
@@ -395,6 +395,7 @@ class MANGOS_DLL_SPEC Group
                 --m_subGroupsCounts[subgroup];
         }
 
+        void CountSingleLooterRoll(Roll* roll);
         void CountTheRoll(Rolls::iterator& roll);           // iterator update to next, in CountRollVote if true
         bool CountRollVote(ObjectGuid const& playerGUID, Rolls::iterator& roll, RollVote vote);
 

--- a/src/game/LootMgr.cpp
+++ b/src/game/LootMgr.cpp
@@ -807,7 +807,7 @@ ByteBuffer& operator<<(ByteBuffer& b, LootView const& lv)
         case GROUP_PERMISSION:
         {
             // if you are not the round-robin group looter, you can only see
-            // blocked rolled items and quest items, and !ffa items
+            // blocked rolled items and !ffa items
             for (uint8 i = 0; i < l.items.size(); ++i)
             {
                 if (!l.items[i].is_looted && !l.items[i].freeforall && l.items[i].AllowedForPlayer(lv.viewer, l.GetLootTarget()))
@@ -895,13 +895,20 @@ ByteBuffer& operator<<(ByteBuffer& b, LootView const& lv)
         for (QuestItemList::const_iterator qi = q_list->begin() ; qi != q_list->end(); ++qi)
         {
             LootItem &item = l.m_questItems[qi->index];
-            if (!qi->is_looted && !item.is_looted)
-            {
-                b << uint8(l.items.size() + (qi - q_list->begin()));
-                b << item;
-                b << uint8(slot_type);                      // allow loot
-                ++itemsShown;
-            }
+
+            if (qi->is_looted || item.is_looted)
+                continue;
+
+            // Allow only the round robin player unless that player is not elligible for item
+            if (!item.freeforall && l.roundRobinPlayer != 0 && lv.viewer->GetGUID() != l.roundRobinPlayer 
+                && lootPlayerQuestItems.find(l.roundRobinPlayer) != lootPlayerQuestItems.end())
+                continue;
+
+            // allow loot
+            b << uint8(l.items.size() + (qi - q_list->begin()));
+            b << item;
+            b << uint8(slot_type);                      
+            ++itemsShown;
         }
     }
 
@@ -933,6 +940,11 @@ ByteBuffer& operator<<(ByteBuffer& b, LootView const& lv)
 
             slot_type = item.GetSlotTypeForSharedLoot(lv.permission, lv.viewer, l.GetLootTarget(), !ci->is_looted);
             if (slot_type >= MAX_LOOT_SLOT_TYPE)
+                continue;
+
+            // Allow only the round robin player unless that player is not elligible for item
+            if (!item.freeforall && l.roundRobinPlayer != 0 && lv.viewer->GetGUID() != l.roundRobinPlayer 
+                && lootPlayerNonQuestNonFFAConditionalItems.find(l.roundRobinPlayer) != lootPlayerNonQuestNonFFAConditionalItems.end())
                 continue;
 
             b << uint8(ci->index) << item;


### PR DESCRIPTION
- Implemented round robin rules to quest items and conditional items 
- If the winner of a greed roll has full bags the loot now stays reserved instead of ffa.
- Fixed single roller group loot not being handed out (happens with Corruptor's Scourgestone when only 1 player has trinket)