### PR TITLE
Extend auction lockout to unfiltered queries as well

### DIFF
--- a/src/game/AuctionHouse/AuctionHouseMgr.cpp
+++ b/src/game/AuctionHouse/AuctionHouseMgr.cpp
@@ -679,6 +679,7 @@ void AuctionHouseObject::BuildListAuctionItems(WorldPacket& data, Player* player
         AuctionHouseClientQuery const& query,
         uint32& count, uint32& totalcount)
 {
+    std::string const& clientIp = player->GetSession()->GetRemoteAddress();
     // Happening often, and easy to deal with
     if (query.auctionMainCategory == 0xffffffff && query.auctionSubCategory == 0xffffffff && query.auctionSlotID == 0xffffffff &&
         query.quality == 0xffffffff && query.levelmin == 0x00 && query.levelmax == 0x00 && query.usable == 0x00 && query.wsearchedname.empty())
@@ -690,6 +691,9 @@ void AuctionHouseObject::BuildListAuctionItems(WorldPacket& data, Player* player
             std::advance(itr, query.listfrom);
             for (; itr != AuctionsMap.end(); ++itr)
             {
+                if (!itr->second->IsAvailableFor(clientIp))
+                    continue;
+
                 itr->second->BuildAuctionInfo(data);
                 if ((++count) >= 50)
                     break;
@@ -699,7 +703,6 @@ void AuctionHouseObject::BuildListAuctionItems(WorldPacket& data, Player* player
     }
 
     time_t currTime = sWorld.GetGameTime();
-    std::string const& clientIp = player->GetSession()->GetRemoteAddress();
     int loc_idx = player->GetSession()->GetSessionDbLocaleIndex();
 
     for (AuctionEntryMap::const_iterator itr = AuctionsMap.begin(); itr != AuctionsMap.end(); ++itr)
@@ -737,7 +740,7 @@ void AuctionHouseObject::BuildListAuctionItems(WorldPacket& data, Player* player
                         continue;
 
             // IP locked auction
-            if (!Aentry->lockedIpAddress.empty() && Aentry->lockedIpAddress != clientIp)
+            if (!Aentry->IsAvailableFor(clientIp))
                 continue;
 
             if (!query.wsearchedname.empty())
@@ -832,4 +835,12 @@ void AuctionEntry::SaveToDB() const
     CharacterDatabase.PExecute("INSERT INTO auction (id,houseid,itemguid,item_template,itemowner,buyoutprice,time,buyguid,lastbid,startbid,deposit) "
                                "VALUES ('%u', '%u', '%u', '%u', '%u', '%u', '" UI64FMTD "', '%u', '%u', '%u', '%u')",
                                Id, auctionHouseEntry->houseId, itemGuidLow, itemTemplate, owner, buyout, (uint64)expireTime, bidder, bid, startbid, deposit);
+}
+
+bool AuctionEntry::IsAvailableFor(std::string const& ip)
+{
+    if (!lockedIpAddress.empty())
+        return lockedIpAddress == ip;
+
+    return true;
 }

--- a/src/game/AuctionHouse/AuctionHouseMgr.h
+++ b/src/game/AuctionHouse/AuctionHouseMgr.h
@@ -81,6 +81,7 @@ struct AuctionEntry
     bool BuildAuctionInfo(WorldPacket & data) const;
     void DeleteFromDB() const;
     void SaveToDB() const;
+    bool IsAvailableFor(std::string const& ip);
 };
 
 struct AuctionHouseClientQuery


### PR DESCRIPTION
Currently the 5 minute IP lockout for posted auctions only applies to those that are searched for with a query parameter set