### PR TITLE
Prevent players from entering Naxx while group is in combat with "the instance"

### DIFF
--- a/src/game/Maps/Map.cpp
+++ b/src/game/Maps/Map.cpp
@@ -1798,7 +1798,8 @@ bool DungeonMap::CanEnter(Player *player)
     Group *pGroup = player->GetGroup();
     if (pGroup && pGroup->InCombatToInstance(GetInstanceId()) && player->isAlive() && player->GetMapId() != GetId())
     {
-        if (GetId() == 249 || GetId() == 531)        // Hack : Ustaag <Nostalrius> : concerne uniquement Onyxia's Lair
+		
+        if (GetId() == 249 || GetId() == 531 || GetId() == 533)        // Hack : Ustaag <Nostalrius> : concerne uniquement Onyxia's Lair
         {
             player->SendTransferAborted(GetId(), TRANSFER_ABORT_ZONE_IN_COMBAT);
             return false;


### PR DESCRIPTION
Ideally we get rid of the entire hack that is extended upon in this PR by utilizing `bool InstanceData::IsEncounterInProgress()`, but before that can be done all existing implementations of that function must be checked to avoid any instance locking players out when it should not.

Closes #211 