### PR TITLE
Update quests 3562, 3563, 3564, 3565 minimum level

### DIFF
--- a/sql/migrations/20171104225441_world.sql
+++ b/sql/migrations/20171104225441_world.sql
@@ -9,10 +9,11 @@ INSERT INTO `migrations` VALUES ('20171104225441');
 -- Add your query below.
 
 --This update brings the following quests minimum level inline with eachother according to:
+-- http://web.archive.org/web/20050316083722/http://wow.allakhazam.com:80/db/quest.html?wquest=3561
 -- http://web.archive.org/web/20050117052220/http://wow.allakhazam.com:80/db/quest.html?wquest=3565
 
 -- Update quest minimum levels
-UPDATE quest_template SET minLevel = 48 WHERE entry IN (3562,3563,3564,3565);
+UPDATE quest_template SET minLevel = 48 WHERE entry IN (3518, 3541, 3542, 3561, 3562, 3563, 3564, 3565);
 
 -- End of migration.
 END IF;

--- a/sql/migrations/20171104225441_world.sql
+++ b/sql/migrations/20171104225441_world.sql
@@ -1,0 +1,22 @@
+DROP PROCEDURE IF EXISTS add_migration;
+delimiter ??
+CREATE PROCEDURE `add_migration`()
+BEGIN
+DECLARE v INT DEFAULT 1;
+SET v = (SELECT COUNT(*) FROM `migrations` WHERE `id`='20171104225441');
+IF v=0 THEN
+INSERT INTO `migrations` VALUES ('20171104225441');
+-- Add your query below.
+
+--This update brings the following quests minimum level inline with eachother according to:
+-- http://web.archive.org/web/20050117052220/http://wow.allakhazam.com:80/db/quest.html?wquest=3565
+
+-- Update quest minimum levels
+UPDATE quest_template SET minLevel = 48 WHERE entry IN (3562,3563,3564,3565);
+
+-- End of migration.
+END IF;
+END??
+delimiter ;
+CALL add_migration();
+DROP PROCEDURE IF EXISTS add_migration;

--- a/sql/migrations/20171104225441_world.sql
+++ b/sql/migrations/20171104225441_world.sql
@@ -8,12 +8,12 @@ IF v=0 THEN
 INSERT INTO `migrations` VALUES ('20171104225441');
 -- Add your query below.
 
---This update brings the following quests minimum level inline with eachother according to:
--- http://web.archive.org/web/20050316083722/http://wow.allakhazam.com:80/db/quest.html?wquest=3561
+-- This updates quest 3562 to be a minimum required level of 45
 -- http://web.archive.org/web/20050117052220/http://wow.allakhazam.com:80/db/quest.html?wquest=3565
+-- (Note archive for 3562 doesn't show a minimum level but it should be the same as 3565)
 
 -- Update quest minimum levels
-UPDATE quest_template SET minLevel = 48 WHERE entry IN (3518, 3541, 3542, 3561, 3562, 3563, 3564, 3565);
+UPDATE quest_template SET minLevel = 45 WHERE entry = 3562;
 
 -- End of migration.
 END IF;


### PR DESCRIPTION
For Horde in Azshara, there are a group of 4 "delivery" quests and 4 follow up "payment to NPC" quests. According to my research, I think that the current database has the minimum level requirements for 3562 set incorrectly:

![screenshot_1](https://user-images.githubusercontent.com/87356/32416110-e072e246-c200-11e7-890f-ba2adbce9f37.png)

Strangely, one of them is minimum requirement of 51 for some reason. That's what made me first suspect a bug here.

After research and @brotalnia 's suggestion, I have made an update that fixed the 3562 quest and changes the minimum level requirement to be in-line with the rest of the quests.