### PR TITLE
Contrib/Tools: Fixed build for extraction tools.

### DIFF
--- a/contrib/mmap/CMakeLists.txt
+++ b/contrib/mmap/CMakeLists.txt
@@ -25,19 +25,17 @@ if(!WIN32)
 endif()
 
 include_directories(
-    ../../src
-    ../../src/shared
-    ../../src/game
-    ../../src/game/vmap
-    ../../dep/include/g3dlite
-    ../../src/framework
-    ../../dep/ACE_wrappers
-    ../../objdir/dep/ACE_wrappers
-    ../../dep/recastnavigation/Detour/Include
-    ../../dep/recastnavigation/Recast/Include
-    ../../dep/src/zlib
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}/src/shared
+    ${CMAKE_SOURCE_DIR}/src/game
+    ${CMAKE_SOURCE_DIR}/src/game/vmap
+    ${CMAKE_SOURCE_DIR}/dep/include/g3dlite
+    ${CMAKE_SOURCE_DIR}/src/framework
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Detour/Include
+    ${CMAKE_SOURCE_DIR}/dep/recastnavigation/Recast/Include
+    ${CMAKE_SOURCE_DIR}/dep/src/zlib
+    ${ACE_INCLUDE_DIR}
 )
-
 
 add_library(vmap
 	../../src/game/vmap/BIH.cpp

--- a/contrib/vmap_assembler/CMakeLists.txt
+++ b/contrib/vmap_assembler/CMakeLists.txt
@@ -24,10 +24,13 @@ ADD_DEFINITIONS("-ggdb")
 ADD_DEFINITIONS("-O3")
 endif()
 
-include_directories(../../src/shared)
-include_directories(../../src/game/vmap/)
-include_directories(../../dep/include/g3dlite/)
-include_directories(../../src/framework/)
+include_directories(
+  ${CMAKE_SOURCE_DIR}/src/shared
+  ${CMAKE_SOURCE_DIR}/src/game/vmap
+  ${CMAKE_SOURCE_DIR}/dep/include/g3dlite
+  ${CMAKE_SOURCE_DIR}/src/framework
+  ${ACE_INCLUDE_DIR}
+)
 
 add_executable(vmap_assembler vmap_assembler.cpp)
 target_link_libraries(vmap_assembler vmap ${ACE_LIBRARIES})

--- a/src/game/Maps/MoveMapSharedDefines.h
+++ b/src/game/Maps/MoveMapSharedDefines.h
@@ -20,7 +20,7 @@
 #define _MOVE_MAP_SHARED_DEFINES_H
 
 #include "Platform/Define.h"
-#include "../recastnavigation/Detour/Include/DetourNavMesh.h"
+#include "../../recastnavigation/Detour/Include/DetourNavMesh.h"
 
 #define MMAP_MAGIC 0x4d4d4150   // 'MMAP'
 #define MMAP_VERSION 3


### PR DESCRIPTION
 - MMaps directly included Ace into build
 - Fixed broken file include (MMapSharedDefines)
 - VMap_assembler directly included ACE into build

Note: the CMake system needs majorly cleaned-up...
Ace does not reside in dep, adjusted linking and fixed build.

Signed-off-by: Bootz <bootz@projectskyfire.org>