### PR TITLE
fix chain multiplier modifiers not benefiting from spell power or healing power

### DIFF
--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -332,8 +332,11 @@ float CalculateCustomCoefficient(SpellEntry const *spellProto, Unit const* caste
 
                     if (Player* modOwner = caster->GetSpellModOwner())
                     {
-                        // Improved Chain Heal (T2 3/8 bonus) / Gift of the Gathering Storm Chain Lightning Bonus
-                        modOwner->ApplySpellMod(spell->m_spellInfo->Id, SPELLMOD_EFFECT_PAST_FIRST, multiplier, spell);
+                        if (spell->GetTargetNum() > 1)
+                        {
+                            // Improved Chain Heal (T2 3/8 bonus) / Gift of the Gathering Storm Chain Lightning Bonus
+                            modOwner->ApplySpellMod(spell->m_spellInfo->Id, SPELLMOD_EFFECT_PAST_FIRST, multiplier, spell);
+                        }
                     }
 
                     for (uint8 i = 1; i < spell->GetTargetNum(); ++i)

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -330,9 +330,9 @@ float CalculateCustomCoefficient(SpellEntry const *spellProto, Unit const* caste
                 {
                     float multiplier = spellProto->DmgMultiplier[0];
 
-                    if (Player* modOwner = caster->GetSpellModOwner())
+                    if (spell->GetTargetNum() > 1)
                     {
-                        if (spell->GetTargetNum() > 1)
+                        if (Player* modOwner = caster->GetSpellModOwner())
                         {
                             // Improved Chain Heal (T2 3/8 bonus) / Gift of the Gathering Storm Chain Lightning Bonus
                             modOwner->ApplySpellMod(spell->m_spellInfo->Id, SPELLMOD_EFFECT_PAST_FIRST, multiplier, spell);

--- a/src/game/Spells/SpellMgr.cpp
+++ b/src/game/Spells/SpellMgr.cpp
@@ -328,8 +328,16 @@ float CalculateCustomCoefficient(SpellEntry const *spellProto, Unit const* caste
                 // Chain Lightning / Chain Heal / Healing Wave (T1 8/8 bonus)
                 if (spellProto->IsFitToFamilyMask(UI64LIT(0x00000000142)))
                 {
+                    float multiplier = spellProto->DmgMultiplier[0];
+
+                    if (Player* modOwner = caster->GetSpellModOwner())
+                    {
+                        // Improved Chain Heal (T2 3/8 bonus) / Gift of the Gathering Storm Chain Lightning Bonus
+                        modOwner->ApplySpellMod(spell->m_spellInfo->Id, SPELLMOD_EFFECT_PAST_FIRST, multiplier, spell);
+                    }
+
                     for (uint8 i = 1; i < spell->GetTargetNum(); ++i)
-                        coeff *= spellProto->DmgMultiplier[0];
+                        coeff *= multiplier;
                     return coeff;
                 }
             }


### PR DESCRIPTION
fixes
#915
#894

I copied the ApplySpellMod from Spell::DoSpellHitOnUnit
https://github.com/LightsHope/server/blob/4d33e2450fad4a314b69e3940ed13f9f4579c08b/src/game/Spells/Spell.cpp#L1632

into CalculateCustomCoefficient. ApplySpellMod has a side effect of dropping mod charges but that is not an issue since these spells do not have charges.

http://vanillawowdb.com/?spell=21899
http://vanillawowdb.com/?spell=26123