### PR TITLE
Azuregos threat drops everyone to circumvent griefing

### DIFF
--- a/src/scripts/world/boss_azuregos.cpp
+++ b/src/scripts/world/boss_azuregos.cpp
@@ -123,10 +123,13 @@ struct boss_azuregosAI : ScriptedAI
             for (ThreatList::const_iterator i = tList.begin(); i != tList.end(); ++i)
             {
                 Unit* pUnit = m_creature->GetMap()->GetUnit((*i)->getUnitGuid());
-                if (pUnit && pUnit->GetTypeId() == TYPEID_PLAYER && pUnit->GetDistance(m_creature) < 45.0f)
+                if (pUnit && pUnit->GetTypeId() == TYPEID_PLAYER)
                 {
                     m_creature->getThreatManager().modifyThreatPercent(pUnit, -100);
-                    DoTeleportPlayer(pUnit, m_creature->GetPositionX(), m_creature->GetPositionY(), m_creature->GetPositionZ() + 5, pUnit->GetOrientation());
+                    if (pUnit->GetDistance(m_creature) < 45.0f)
+                    {
+                        DoTeleportPlayer(pUnit, m_creature->GetPositionX(), m_creature->GetPositionY(), m_creature->GetPositionZ() + 5, pUnit->GetOrientation());
+                    }
                 }
             }
 


### PR DESCRIPTION
At this moment there is a range check for Azuregos' teleport ability, this can intentionally or unintentionally make Azuregos reset. This has happened multiple times on the Lightbringer realm. If a player is on the threat table an is further than 45 yards away after a teleport Azuregos will run to that person, if that player is far away the boss will run so fast that it is almost impossible for the engaging raid to reestablish threat on the boss eventually it will run out of range and the boss will reset.

My proposed solution to circumvent griefing like this is to this is to have the range check only to see which people he pulls to him while not for the threat drop portion of the spell. That is on teleport all threat is reset and only the players within 45yds will be pulled in.