### PR TITLE
Battlegrounds maximum team size difference

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 Before opening any bug reports on the issue tracker, please read the guidelines [located here](https://github.com/LightsHope/server/blob/development/docs/).
 
 # Development process overview:
-Any development work should be done in local feature branches rather than on the main branches used for QA/live builds. For example, if you were working on a boss script, rather than committing directly to the development branch, you should first create a new branch with a descriptive name.
+Development work must be done by forking server to your own GitHub account and in your fork, making a new branch with a descriptive name, committing the new work to that branch and then issing a pull request to allow for your code to be automatically compiled by the continuous integration system and reviewed by other developers.
 
-When you have finished working on your fix or feature, you should open a pull request to allow for your code to be automatically compiled by the continuous integration system and reviewed by other developers. After receiving feedback and making any requested changes, your pull request will be squashed and merged to the development branch. Squashing your commits is to ensure that the development branch can be compiled at any point in its history as well as ensuring a clean history.
+After receiving feedback and making any requested changes, your pull request will be squashed and merged to the development branch. Squashing your commits is to ensure that the development branch can be compiled at any point in its history as well as ensuring a clean history.
 
 The development branch is used as the basis for the QA and PTR realms. To ensure the QA team receives ample opportunity to test each set of changes, the development branch will only accept pull requests for one week before being frozen for a week, during which time only essential fixes will be accepted.
 

--- a/src/game/Battlegrounds/BattleGroundMgr.cpp
+++ b/src/game/Battlegrounds/BattleGroundMgr.cpp
@@ -478,7 +478,7 @@ void BattleGroundQueue::FillPlayersToBG(BattleGround* bg, BattleGroundBracketId 
     int32 hordeFree = bg->GetFreeSlotsForTeam(HORDE);
     int32 aliFree   = bg->GetFreeSlotsForTeam(ALLIANCE);
 
-    int8 bg_differential = 1; // default differential between Horde & Alliance
+    int8 bg_differential = 0; // default differential between Horde & Alliance
 
     //if (bg->GetTypeID() == BATTLEGROUND_AV)
     //  bg_differential = 3;    // custom differential between Horde & Alliance for Alterac Valley


### PR DESCRIPTION
Change maximum difference in team sizes from 1 to 0.

Where faction populations are not equal, there are from the larger faction always or almost always more players queuing, which means that the larger faction team is always or almost always as much larger than the small faction team as permitted by the maximum difference in team sizes.

A difference of only one player is enough for the larger team to always or almost always win.

On LH, Horde is the larger faction, on Darrow, Alliance, and it is seen that on LH, the Horde team is always or almost always one larger than the Alliance team, and vis-verse on Darrow.

This has a feedback effect, where the smaller faction always or almost always loses, and so its players stop queuing.

In short, even a difference of one means that BGs, by design, always or almost always lead one faction to win, consistently, on a per-server basis.

The existing server enforced team size difference of one was introduced presumably to ensure the teams are not so unbalanced that one team will inevitably win; but what has been done, with a limit of one, does not in fact achieve the intended purpose.  A maximum difference of zero will.

Please see issue 1071 for discussion.

https://github.com/LightsHope/server/issues/1071
