### PR TITLE
shield slam + bash weaponprocs

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -1329,7 +1329,15 @@ void Spell::DoAllEffectOnTarget(TargetInfo *target)
             {
                  ((Player*)m_caster)->CastItemCombatSpell(unitTarget, BASE_ATTACK);
             }
-
+	    	//yoshgit pull from elysium that was denied cos of ""vanilla bug""
+		//https://github.com/elysium-project/server/pull/1029/files
+	    else if (m_spellInfo->IsFitToFamilyMask<CF_WARRIOR_SHIELD_BASH>() || //shield bash
+-              && m_spellInfo->SpellIconID == 280)
++                m_spellInfo->IsFitToFamilyMask<CF_WARRIOR_SHIELD_SLAM>()) //shield slam
+-                ((Player*)m_caster)->CastItemCombatSpell(unitTarget, BASE_ATTACK);
++                {
++                    ((Player*)m_caster)->CastItemCombatSpell(unitTarget, BASE_ATTACK);
++                }
             // special Paladin cases - trigger weapon procs despite not having EquippedItemClass
             else if (m_spellInfo->SpellFamilyName == SPELLFAMILY_PALADIN)
             {


### PR DESCRIPTION
#1088 
2.0.1 Patch notes:
http://eu.battle.net/wow/en/game/patch-notes/2-0-1

>Warrior "Shield Slam" and "Shield Bash" will no longer trigger a proc from an equipped weapon.
