### PR TITLE
Followup to AV honor gains

### DIFF
--- a/src/game/Battlegrounds/BattleGround.cpp
+++ b/src/game/Battlegrounds/BattleGround.cpp
@@ -741,7 +741,8 @@ uint32 BattleGround::GetBonusHonorFromKill(uint32 kills) const
 
 float BattleGround::GetHonorModifier() {
     // If the game ends in under one hour, less Bonus Honor will be earned from control of mines, graveyards and for the General kill (win).
-    return GetStartTime() < HOUR * IN_MILLISECONDS ? 0.5f : 1.0f;
+    float elapsed = (float)GetStartTime() / IN_MILLISECONDS / HOUR;
+    return elapsed < 1.0f ? pow(60, elapsed - 1) : 1.0f;
 }
 
 uint32 BattleGround::GetBattlemasterEntry() const

--- a/src/game/Battlegrounds/BattleGroundAV.cpp
+++ b/src/game/Battlegrounds/BattleGroundAV.cpp
@@ -960,7 +960,7 @@ void BattleGroundAV::EndBattleGround(Team winner)
         if (tower_survived[i])
         {
             RewardReputationToTeam(faction[i], tower_survived[i] * m_RepSurviveTower, team[i]);
-            RewardHonorToTeam(GetBonusHonorFromKill(tower_survived[i] * BG_AV_KILL_SURVIVING_TOWER), team[i]);
+            RewardHonorToTeam(uint32(GetBonusHonorFromKill(tower_survived[i] * BG_AV_KILL_SURVIVING_TOWER) * GetHonorModifier()), team[i]);
         }
         DEBUG_LOG("BattleGroundAV: EndbattleGround: bgteam: %u towers:%u honor:%u rep:%u", i, tower_survived[i], GetBonusHonorFromKill(tower_survived[i] * BG_AV_KILL_SURVIVING_TOWER), tower_survived[i] * BG_AV_REP_SURVIVING_TOWER);
         if (graves_owned[i])
@@ -989,13 +989,6 @@ void BattleGroundAV::EndBattleGround(Team winner)
             RewardHonorToTeam(396, HORDE);
         if (winner == ALLIANCE)
             RewardHonorToTeam(396, ALLIANCE);
-    }
-
-    // both teams:
-    if (m_HonorMapComplete)
-    {
-        RewardHonorToTeam(m_HonorMapComplete, ALLIANCE);
-        RewardHonorToTeam(m_HonorMapComplete, HORDE);
     }
     BattleGround::EndBattleGround(winner);
 }
@@ -1570,7 +1563,6 @@ void BattleGroundAV::Reset()
     // set the reputation and honor variables:
     bool isBGWeekend = BattleGroundMgr::IsBGWeekend(GetTypeID());
 
-    m_HonorMapComplete    = (isBGWeekend) ? BG_AV_KILL_MAP_COMPLETE_HOLIDAY      : BG_AV_KILL_MAP_COMPLETE;
     m_RepTowerDestruction = (isBGWeekend) ? BG_AV_REP_TOWER_HOLIDAY              : BG_AV_REP_TOWER;
     m_RepCommander        = (isBGWeekend) ? BG_AV_REP_COMMANDER_HOLIDAY          : BG_AV_REP_COMMANDER;
     m_RepCaptain          = (isBGWeekend) ? BG_AV_REP_CAPTAIN_HOLIDAY            : BG_AV_REP_CAPTAIN;

--- a/src/game/Battlegrounds/BattleGroundAV.h
+++ b/src/game/Battlegrounds/BattleGroundAV.h
@@ -526,7 +526,6 @@ class BattleGroundAV : public BattleGround
 
         bool m_IsInformedNearLose[BG_TEAMS_COUNT];
 
-        uint32 m_HonorMapComplete;
         uint32 m_RepTowerDestruction;
         uint32 m_RepCommander;
         uint32 m_RepCaptain;


### PR DESCRIPTION
The previous fix to AV honor gains has some implications to the pvp community: https://github.com/LightsHope/server/pull/876
The increase in honor could lead to other BGs becoming abandoned since its far more efficient to just spam  10 minute AVs.

The honor reward for a 10 minute win, with all objectives up at the end:
Before:
Not weekend: 199
AV weekend: 2179

After #876:
Not weekend: 4158
AV weekend: 6158

Currently the 2k reward during AV weekend is enough for most people to switch to AV so its obvious these numbers are too high.
Proposed solution:
- Include Towers in the short game honor reduction.
- Change the honor reduction from a flat 50% to a logarithmic scale 60^(x-1).

Values for a 10 minute win after this:
Not weekend: 751
AV weekend: 2731