### PR TITLE
Misschance adjustment round three

### DIFF
--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2827,7 +2827,7 @@ float Unit::MeleeSpellMissChance(Unit *pVictim, WeaponAttackType attType, int32 
     float hitChance = 0.0f;
 
     // PvP - PvE melee chances
-    else if (pVictim->GetTypeId() == TYPEID_PLAYER)
+    if (pVictim->GetTypeId() == TYPEID_PLAYER)
         hitChance = 95.0f + skillDiff * 0.04f;
     else if (skillDiff < -10)
         hitChance = 93.4f + (skillDiff + 10) * 0.4f;

--- a/src/game/Objects/Unit.cpp
+++ b/src/game/Objects/Unit.cpp
@@ -2827,14 +2827,12 @@ float Unit::MeleeSpellMissChance(Unit *pVictim, WeaponAttackType attType, int32 
     float hitChance = 0.0f;
 
     // PvP - PvE melee chances
-    if (GetTypeId() == TYPEID_PLAYER && pVictim->GetTypeId() == TYPEID_PLAYER)
-        hitChance = 95.0f + skillDiff * 0.04f;  // PvP misschance base is 5.00%
     else if (pVictim->GetTypeId() == TYPEID_PLAYER)
-        hitChance = 94.4f + skillDiff * 0.04f;
+        hitChance = 95.0f + skillDiff * 0.04f;
     else if (skillDiff < -10)
-        hitChance = 93.4f + (skillDiff + 10) * 0.4f;        // 7% ~ 6.60% base chance to miss for big skill diff
+        hitChance = 93.4f + (skillDiff + 10) * 0.4f;
     else
-        hitChance = 94.4f + skillDiff * 0.1f;
+        hitChance = 95.0f + skillDiff * 0.16f;
 
     // Hit chance depends from victim auras
     if (attType == RANGED_ATTACK)
@@ -3161,13 +3159,7 @@ float Unit::MeleeMissChanceCalc(const Unit *pVictim, WeaponAttackType attType) c
     if (!pVictim || !pVictim->IsStandState())
         return 0.0f;
 
-    float missChance = 5.60f; // The base chance to miss is 5.60%
-
-    // The base chance to miss in PvP is 5%
-    if (GetTypeId() == TYPEID_PLAYER && pVictim->GetTypeId() == TYPEID_PLAYER)
-    {
-        missChance = 5.00f;
-    }
+    float missChance = 5.00f; // The base chance to miss is 5.00%
 
     // DualWield - white damage has an additional 19% miss penalty
     if (haveOffhandWeapon() && attType != RANGED_ATTACK)
@@ -3191,9 +3183,9 @@ float Unit::MeleeMissChanceCalc(const Unit *pVictim, WeaponAttackType attType) c
     if (pVictim->GetTypeId() == TYPEID_PLAYER)
         missChance -= skillDiff * 0.04f;
     else if (skillDiff < -10)
-        missChance -= (skillDiff + 10) * 0.4f - 1.0f;       // 7% ~ 6.60% base chance to miss for big skill diff
+        missChance = 5.60f - (skillDiff + 10) * 0.4f - 1.0f;
     else
-        missChance -=  skillDiff * 0.1f;
+        missChance -=  skillDiff * 0.16f;
 
     // Hit chance bonus from attacker based on ratings and auras
     if (attType == RANGED_ATTACK)


### PR DESCRIPTION
This adjusts the miss chance calculation to use a 5% base value against same skill targets, instead of 5.60%. Details can be seen in https://github.com/LightsHope/server/issues/844